### PR TITLE
feat: implementing configuration for ballots

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - epic/*
   push:
     branches:
       - main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.9.0-alpha.2"
 log = "0.4.22"
 rkyv = { version = "0.7.44", features = ["validation"]}
 serde = { version = "1.0.207", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ log = "0.4.22"
 rkyv = { version = "0.7.44", features = ["validation"]}
 serde = { version = "1.0.207", features = ["derive"] }
 bincode = "1.3.3"
+tokio = { version = "1.39.2", features = ["full", "test-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ rkyv = { version = "0.7.44", features = ["validation"]}
 serde = { version = "1.0.207", features = ["derive"] }
 bincode = "1.3.3"
 tokio = { version = "1.39.2", features = ["full", "test-util"] }
+rand = "0.9.0-alpha.2"
+seeded-random = "0.6.0"

--- a/src/party.rs
+++ b/src/party.rs
@@ -391,6 +391,11 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
     fn update_state(&mut self, m: AlignedVec, routing: MessageRouting) -> Result<(), BallotError> {
         match routing.msg_type {
             ProtocolMessage::Msg1a => {
+                if self.status != PartyStatus::Launched {
+                    return Err(BallotError::InvalidState(
+                        "Received Msg1a message, while party status is not <Launched>".into(),
+                    ));
+                }
                 let archived =
                     rkyv::check_archived_root::<Message1aContent>(&m[..]).map_err(|err| {
                         BallotError::MessageParsing(format!("Validation error: {:?}", err))
@@ -414,6 +419,11 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
                 self.status = PartyStatus::Passed1a;
             }
             ProtocolMessage::Msg1b => {
+                if self.status != PartyStatus::Passed1a {
+                    return Err(BallotError::InvalidState(
+                        "Received Msg1b message, while party status is not <Passed1a>".into(),
+                    ));
+                }
                 let archived =
                     rkyv::check_archived_root::<Message1bContent>(&m[..]).map_err(|err| {
                         BallotError::MessageParsing(format!("Validation error: {:?}", err))
@@ -457,6 +467,11 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
                 }
             }
             ProtocolMessage::Msg2a => {
+                if self.status != PartyStatus::Passed1b {
+                    return Err(BallotError::InvalidState(
+                        "Received Msg2a message, while party status is not <Passed1b>".into(),
+                    ));
+                }
                 let archived =
                     rkyv::check_archived_root::<Message2aContent>(&m[..]).map_err(|err| {
                         BallotError::MessageParsing(format!("Validation error: {:?}", err))
@@ -494,6 +509,11 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
                 }
             }
             ProtocolMessage::Msg2av => {
+                if self.status != PartyStatus::Passed2a {
+                    return Err(BallotError::InvalidState(
+                        "Received Msg2av message, while party status is not <Passed2a>".into(),
+                    ));
+                }
                 let archived =
                     rkyv::check_archived_root::<Message2avContent>(&m[..]).map_err(|err| {
                         BallotError::MessageParsing(format!("Validation error: {:?}", err))
@@ -535,6 +555,11 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
                 }
             }
             ProtocolMessage::Msg2b => {
+                if self.status != PartyStatus::Passed2av {
+                    return Err(BallotError::InvalidState(
+                        "Received Msg2b message, while party status is not <Passed2av>".into(),
+                    ));
+                }
                 let archived =
                     rkyv::check_archived_root::<Message2bContent>(&m[..]).map_err(|err| {
                         BallotError::MessageParsing(format!("Validation error: {:?}", err))

--- a/src/party.rs
+++ b/src/party.rs
@@ -24,6 +24,11 @@ pub struct BPConConfig {
     /// Threshold weight to define BFT quorum: should be > 2/3 of total weight
     pub threshold: u128,
 
+    /// Timeout before ballot is launched.
+    /// Differs from `launch1a_timeout` having another status and not listening
+    /// to external events and messages.
+    pub launch_timeout: Duration,
+
     /// Timeout before 1a stage is launched.
     pub launch1a_timeout: Duration,
 
@@ -274,6 +279,8 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
 
     pub async fn launch_ballot(&mut self) -> Result<Option<V>, BallotError> {
         self.prepare_next_ballot();
+        time::sleep(self.cfg.launch_timeout).await;
+
         self.status = PartyStatus::Launched;
 
         let launch1a_timer = time::sleep(self.cfg.launch1a_timeout);
@@ -755,6 +762,7 @@ mod tests {
         BPConConfig {
             party_weights: vec![1, 2, 3],
             threshold: 4,
+            launch_timeout: Duration::from_secs(0),
             launch1a_timeout: Duration::from_secs(0),
             launch1b_timeout: Duration::from_secs(10),
             launch2a_timeout: Duration::from_secs(20),


### PR DESCRIPTION
# What?

This PR contains additions to config and is closing end-to-end functionality of launch for ballot.

Key changes:

1. Add timeouts to work with scheduled consensus events (launch 1a, launch 1b etc.)
2. Add test to check this functionality.
3. Add ballot number to leader election seed.