### PR TITLE
Rewriting the hash_to_range function 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - epic/*
   push:
     branches:
       - main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ rkyv = { version = "0.7.44", features = ["validation"]}
 serde = { version = "1.0.207", features = ["derive"] }
 bincode = "1.3.3"
 tokio = { version = "1.39.2", features = ["full", "test-util"] }
+rand = "0.9.0-alpha.2"
+seeded-random = "0.6.0"

--- a/src/party.rs
+++ b/src/party.rs
@@ -159,6 +159,8 @@ impl DefaultLeaderElector {
             if raw_res < range {
                 return raw_res;
             }
+            // Executing this loop does not require a large number of iterations.
+            // Check tests for more info
         }
     }
 }


### PR DESCRIPTION
Rewriting the hash_to_range function to achieve better uniform distribution.

Now it uses seeded random based on ChaCha12Rng instead of DefaultHash as before. Also, it fixes distribution in range by executing selection several times to achieve uniform distribution when range != 2^k