### PR TITLE
feat: enhanced end-to-end tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,9 +53,11 @@ jobs:
   test:
     name: Test Suite
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta, nightly]
+        retries: [1, 2, 3]  # We have non-deterministic tests, which depend on computational power.
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -133,4 +133,4 @@ jobs:
         continue-on-error: false
         with:
           command: clippy
-          args: --all-targets -- -D warnings
+          args: --all-targets --all-features -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,9 @@ on:
 permissions:
   contents: read
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   check:
     name: Check
@@ -53,11 +56,9 @@ jobs:
   test:
     name: Test Suite
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta, nightly]
-        retries: [1, 2, 3]  # We have non-deterministic tests, which depend on computational power.
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
@@ -85,12 +86,14 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
 
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        continue-on-error: false
+      - name: Install Nextest
+        uses: taiki-e/install-action@v2
         with:
-          command: test
-          args: --all-features --verbose
+          tool: nextest
+
+      - name: Run Nextest
+        # We have non-deterministic integration tests, thus adding retries.
+        run: cargo nextest run --all-features --retries 3
 
   lints:
     name: Lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "^1.39.2", features = ["full"] }
 rand = "^0.9.0-alpha.2"
 seeded-random = "^0.6.0"
 thiserror = "^1.0.63"
+futures = "0.3.30"
 
 [features]
 default = ["tokio/full", "rkyv/validation"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ test-mocks = []
 [dev-dependencies]
 tokio = { version = "^1.39.2", features = ["test-util"] }
 futures = "0.3.30"
+
+[[test]]
+name = "mod"
+required-features = ["test-mocks"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,13 @@ seeded-random = "^0.6.0"
 thiserror = "^1.0.63"
 
 [features]
-default = ["full"]
-full = ["tokio/full", "rkyv/validation"]
+default = ["tokio/full", "rkyv/validation"]
+test-mocks = []
 
 [dev-dependencies]
 tokio = { version = "^1.39.2", features = ["test-util"] }
+
+[[test]]
+name = "mod"
+path = "tests/mod.rs"
+required-features = ["test-mocks"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "BPCon: A Byzantine Fault-Tolerant Consensus Protocol Implementation in Rust."
 license = "MIT"
 repository = "https://github.com/distributed-lab/bpcon"
-homepage = "https://github.com/distributed-lab/bpcon"
+homepage = "https://github.com/distributed-lab/bpcon#readme"
 documentation = "https://distributed-lab.github.io/bpcon/"
 keywords = ["consensus", "byzantine", "protocol", "distributed-systems", "blockchain"]
 categories = ["algorithms"]
@@ -21,7 +21,6 @@ tokio = { version = "^1.39.2", features = ["full"] }
 rand = "^0.9.0-alpha.2"
 seeded-random = "^0.6.0"
 thiserror = "^1.0.63"
-futures = "0.3.30"
 
 [features]
 default = ["tokio/full", "rkyv/validation"]
@@ -29,8 +28,4 @@ test-mocks = []
 
 [dev-dependencies]
 tokio = { version = "^1.39.2", features = ["test-util"] }
-
-[[test]]
-name = "mod"
-path = "tests/mod.rs"
-required-features = ["test-mocks"]
+futures = "0.3.30"

--- a/README.md
+++ b/README.md
@@ -132,4 +132,4 @@ In a way, you shall propagate outgoing messages to other parties like:
 1. Listen for outgoing message using `msg_out_receiver`.
 2. Forward it to other parties using `msg_in_sender`.
 
-We welcome you to check `test_end_to_end_ballot` in `party.rs` for example.
+We welcome you to check our [integration tests](./tests) for examples.

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,14 +96,14 @@ impl BPConConfig {
             party_weights,
             threshold,
             // TODO: deduce actually good defaults.
-            launch_timeout: Duration::from_secs(0),
-            launch1a_timeout: Duration::from_secs(5),
-            launch1b_timeout: Duration::from_secs(10),
-            launch2a_timeout: Duration::from_secs(15),
-            launch2av_timeout: Duration::from_secs(20),
-            launch2b_timeout: Duration::from_secs(25),
-            finalize_timeout: Duration::from_secs(30),
-            grace_period: Duration::from_secs(1),
+            launch_timeout: Duration::from_millis(0),
+            launch1a_timeout: Duration::from_millis(200),
+            launch1b_timeout: Duration::from_millis(400),
+            launch2a_timeout: Duration::from_millis(600),
+            launch2av_timeout: Duration::from_millis(800),
+            launch2b_timeout: Duration::from_millis(1000),
+            finalize_timeout: Duration::from_millis(1200),
+            grace_period: Duration::from_millis(0),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,6 +137,6 @@ impl BPConConfig {
     /// In the example above, the total weight is 150, and the BFT threshold is calculated as `2/3 * 150 = 100`.
     pub fn compute_bft_threshold(party_weights: Vec<u64>) -> u128 {
         let total_weight: u128 = party_weights.iter().map(|&w| w as u128).sum();
-        (2 * total_weight) / 3
+        (2 * total_weight + 2) / 3 // adding 2 to keep division ceiling.
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub struct BPConConfig {
 
     /// Threshold weight to define BFT quorum.
     ///
-    /// This value must be greater than 2/3 of the total weight of all parties combined.
+    /// This value must be greater than or equal to 2/3 of the total weight of all parties combined.
     /// The quorum is the minimum weight required to make decisions in the BPCon protocol.
     pub threshold: u128,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 //! Definitions central to BPCon configuration.
 
 use std::time::Duration;
+use tokio::time::Instant;
 
 /// Configuration structure for BPCon.
 ///
@@ -22,11 +23,11 @@ pub struct BPConConfig {
     /// The quorum is the minimum weight required to make decisions in the BPCon protocol.
     pub threshold: u128,
 
-    /// Timeout before the ballot is launched.
+    /// Absolute time, at which party begins to work.
     ///
     /// This timeout differs from `launch1a_timeout` as it applies to a distinct status
     /// and does not involve listening to external events and messages.
-    pub launch_timeout: Duration,
+    pub launch_at: Instant,
 
     /// Timeout before the 1a stage is launched.
     ///
@@ -96,7 +97,7 @@ impl BPConConfig {
             party_weights,
             threshold,
             // TODO: deduce actually good defaults.
-            launch_timeout: Duration::from_millis(0),
+            launch_at: Instant::now(),
             launch1a_timeout: Duration::from_millis(200),
             launch1b_timeout: Duration::from_millis(400),
             launch2a_timeout: Duration::from_millis(600),

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,4 +106,37 @@ impl BPConConfig {
             grace_period: Duration::from_millis(0),
         }
     }
+
+    /// Compute the Byzantine Fault Tolerance (BFT) threshold for the consensus protocol.
+    ///
+    /// This function calculates the minimum weight required to achieve a BFT quorum.
+    /// In BFT systems, consensus is typically reached when more than two-thirds
+    /// of the total weight is gathered from non-faulty parties.
+    ///
+    /// # Parameters
+    ///
+    /// - `party_weights`: A vector of weights corresponding to each party involved in the consensus.
+    ///   These weights represent the voting power or influence of each party in the protocol.
+    ///
+    /// # Returns
+    ///
+    /// The BFT threshold as a `u128` value, which represents the minimum total weight
+    /// required to achieve consensus in a Byzantine Fault Tolerant system. This is calculated
+    /// as two-thirds of the total party weights.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bpcon::config::BPConConfig;
+    ///
+    /// let party_weights = vec![10, 20, 30, 40, 50];
+    /// let threshold = BPConConfig::compute_bft_threshold(party_weights);
+    /// assert_eq!(threshold, 100);
+    /// ```
+    ///
+    /// In the example above, the total weight is 150, and the BFT threshold is calculated as `2/3 * 150 = 100`.
+    pub fn compute_bft_threshold(party_weights: Vec<u64>) -> u128 {
+        let total_weight: u128 = party_weights.iter().map(|&w| w as u128).sum();
+        (2 * total_weight) / 3
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,6 @@ pub mod error;
 pub mod leader;
 pub mod message;
 pub mod party;
+#[cfg(any(test, feature = "test-mocks"))]
+pub mod test_mocks;
 pub mod value;

--- a/src/message.rs
+++ b/src/message.rs
@@ -30,7 +30,7 @@ pub struct MessageRouting {
 ///
 /// These message types represent the various stages of the BPCon consensus protocol,
 /// each corresponding to a specific phase in the process.
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub enum ProtocolMessage {
     Msg1a,
     Msg1b,

--- a/src/party.rs
+++ b/src/party.rs
@@ -327,7 +327,9 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
                         debug!("Party {} received {} from party {}", self.id, msg.routing.msg_type, msg.routing.sender);
                         if let Err(err) = self.update_state(&msg) {
                             // Shouldn't fail the party, since invalid message
-                            // may be sent by anyone.
+                            // may be sent by anyone. Furthermore, since in consensus
+                            // we are relying on redundancy of parties, we actually may need
+                            // less messages than from every party to transit to next status.
                             warn!("Failed to update state with {}, got error: {err}", msg.routing.msg_type)
                         }
                     }else if self.msg_in_receiver.is_closed(){

--- a/src/party.rs
+++ b/src/party.rs
@@ -1004,15 +1004,19 @@ pub(crate) mod tests {
         assert_eq!(event_receiver.recv().await.unwrap(), PartyEvent::Finalize);
     }
 
+    // Type aggregating `receiver from` and `sender into` party, which are
+    // intended for external system to communicate with the party.
+    type PartyExternalChannels = (
+        UnboundedReceiver<MessagePacket>,
+        UnboundedSender<MessagePacket>,
+    );
+
     // Create test parties with predefined generics, based on config.
     fn create_parties(
         cfg: BPConConfig,
     ) -> (
         Vec<Party<MockValue, MockValueSelector>>,
-        Vec<(
-            UnboundedReceiver<MessagePacket>,
-            UnboundedSender<MessagePacket>,
-        )>,
+        Vec<PartyExternalChannels>,
     ) {
         let value_selector = MockValueSelector;
         let leader_elector = Box::new(DefaultLeaderElector::new());

--- a/src/party.rs
+++ b/src/party.rs
@@ -25,7 +25,7 @@ use std::cmp::PartialEq;
 use std::collections::hash_map::Entry::Vacant;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
-use tokio::time::sleep;
+use tokio::time::{sleep, sleep_until};
 
 /// Represents the status of a `Party` in the BPCon consensus protocol.
 ///
@@ -256,7 +256,7 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
     pub async fn launch_ballot(&mut self) -> Result<V, LaunchBallotError> {
         self.prepare_next_ballot()?;
 
-        sleep(self.cfg.launch_timeout).await;
+        sleep_until(self.cfg.launch_at).await;
 
         let launch1a_timer = sleep(self.cfg.launch1a_timeout);
         let launch1b_timer = sleep(self.cfg.launch1b_timeout);
@@ -938,8 +938,6 @@ mod tests {
         _ = tokio::spawn(async move {
             _ = party.launch_ballot().await;
         });
-
-        time::advance(cfg.launch_timeout).await;
 
         // Sequential time advance and event check.
 

--- a/src/party.rs
+++ b/src/party.rs
@@ -474,7 +474,7 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
                     self.messages_1b_weight +=
                         self.cfg.party_weights[routing.sender as usize] as u128;
 
-                    if self.messages_1b_weight > self.cfg.threshold {
+                    if self.messages_1b_weight >= self.cfg.threshold {
                         self.status = PartyStatus::Passed1b;
                     }
                 }
@@ -554,7 +554,7 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
                         self.cfg.party_weights[routing.sender as usize] as u128,
                     );
 
-                    if self.messages_2av_state.get_weight() > self.cfg.threshold {
+                    if self.messages_2av_state.get_weight() >= self.cfg.threshold {
                         self.status = PartyStatus::Passed2av;
                     }
                 }
@@ -586,7 +586,7 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
                         self.cfg.party_weights[routing.sender as usize] as u128,
                     );
 
-                    if self.messages_2b_state.get_weight() > self.cfg.threshold {
+                    if self.messages_2b_state.get_weight() >= self.cfg.threshold {
                         self.status = PartyStatus::Passed2b;
                     }
                 }
@@ -1122,7 +1122,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_ballot_happy_case() {
-        let cfg = BPConConfig::with_default_timeouts(vec![1, 1, 1, 1], 2);
+        let cfg = BPConConfig::with_default_timeouts(vec![1, 1, 1, 1], 3);
 
         let (parties, channels) = create_parties(cfg);
 

--- a/src/party.rs
+++ b/src/party.rs
@@ -474,7 +474,8 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
                     self.messages_1b_weight +=
                         self.cfg.party_weights[routing.sender as usize] as u128;
 
-                    if self.messages_1b_weight >= self.cfg.threshold {
+                    let self_weight = self.cfg.party_weights[self.id as usize] as u128;
+                    if self.messages_1b_weight >= self.cfg.threshold - self_weight {
                         self.status = PartyStatus::Passed1b;
                     }
                 }
@@ -554,7 +555,8 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
                         self.cfg.party_weights[routing.sender as usize] as u128,
                     );
 
-                    if self.messages_2av_state.get_weight() >= self.cfg.threshold {
+                    let self_weight = self.cfg.party_weights[self.id as usize] as u128;
+                    if self.messages_2av_state.get_weight() >= self.cfg.threshold - self_weight {
                         self.status = PartyStatus::Passed2av;
                     }
                 }
@@ -586,7 +588,8 @@ impl<V: Value, VS: ValueSelector<V>> Party<V, VS> {
                         self.cfg.party_weights[routing.sender as usize] as u128,
                     );
 
-                    if self.messages_2b_state.get_weight() >= self.cfg.threshold {
+                    let self_weight = self.cfg.party_weights[self.id as usize] as u128;
+                    if self.messages_2b_state.get_weight() >= self.cfg.threshold - self_weight {
                         self.status = PartyStatus::Passed2b;
                     }
                 }
@@ -1143,7 +1146,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_ballot_faulty_party() {
-        let cfg = BPConConfig::with_default_timeouts(vec![1, 1, 1, 1], 2);
+        let cfg = BPConConfig::with_default_timeouts(vec![1, 1, 1, 1], 3);
 
         let (mut parties, mut channels) = create_parties(cfg);
 

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -31,7 +31,9 @@ impl ValueSelector<MockValue> for MockValueSelector {
 
 impl Default for BPConConfig {
     fn default() -> Self {
-        BPConConfig::with_default_timeouts(vec![1, 1, 1, 1], 3)
+        let weights = vec![1, 1, 1, 1];
+        let threshold = BPConConfig::compute_bft_threshold(weights.clone());
+        BPConConfig::with_default_timeouts(weights, threshold)
     }
 }
 

--- a/src/test_mocks.rs
+++ b/src/test_mocks.rs
@@ -1,0 +1,50 @@
+use crate::config::BPConConfig;
+use crate::leader::DefaultLeaderElector;
+use crate::party::Party;
+use crate::value::{Value, ValueSelector};
+use std::collections::HashMap;
+use std::fmt;
+
+#[derive(Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Debug, Default)]
+pub struct MockValue(u64);
+
+impl fmt::Display for MockValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MockValue: {}", self.0)
+    }
+}
+
+impl Value for MockValue {}
+
+#[derive(Clone, Default)]
+pub struct MockValueSelector;
+
+impl ValueSelector<MockValue> for MockValueSelector {
+    fn verify(&self, _: &MockValue, _: &HashMap<u64, Option<MockValue>>) -> bool {
+        true // For testing, always return true.
+    }
+
+    fn select(&self, _: &HashMap<u64, Option<MockValue>>) -> MockValue {
+        MockValue(1) // For testing, always return the same value.
+    }
+}
+
+impl Default for BPConConfig {
+    fn default() -> Self {
+        BPConConfig::with_default_timeouts(vec![1, 1, 1, 1], 3)
+    }
+}
+
+pub type MockParty = Party<MockValue, MockValueSelector>;
+
+impl Default for MockParty {
+    fn default() -> Self {
+        MockParty::new(
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Box::new(DefaultLeaderElector::default()),
+        )
+        .0
+    }
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -267,7 +267,7 @@ async fn test_ballot_many_parties() {
     let cfg = BPConConfig {
         party_weights,
         threshold,
-        launch_timeout: Duration::from_secs(0),
+        launch_at: Instant::now(),
         launch1a_timeout: Duration::from_secs(0), // 1a's and 2a's are sent only by leader
         launch1b_timeout: Duration::from_secs(1), // meaning we need to wait less.
         launch2a_timeout: Duration::from_secs(5),

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,231 @@
+use bpcon::config::BPConConfig;
+use bpcon::error::LaunchBallotError;
+use bpcon::leader::DefaultLeaderElector;
+use bpcon::message::{Message1bContent, MessagePacket};
+use bpcon::party::Party;
+
+use bpcon::test_mocks::{MockParty, MockValue, MockValueSelector};
+
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::task::JoinHandle;
+use tokio::time;
+
+// Here each party/receiver/sender shall correspond at equal indexes.
+type PartiesWithChannels = (
+    Vec<MockParty>,
+    Vec<UnboundedReceiver<MessagePacket>>,
+    Vec<UnboundedSender<MessagePacket>>,
+);
+
+// Create test parties with predefined generics, based on config.
+fn create_parties(cfg: BPConConfig) -> PartiesWithChannels {
+    (0..cfg.party_weights.len())
+        .map(|i| {
+            MockParty::new(
+                i as u64,
+                cfg.clone(),
+                MockValueSelector,
+                Box::new(DefaultLeaderElector::new()),
+            )
+        })
+        .fold(
+            (Vec::new(), Vec::new(), Vec::new()),
+            |(mut parties, mut receivers, mut senders), (p, r, s)| {
+                parties.push(p);
+                receivers.push(r);
+                senders.push(s);
+                (parties, receivers, senders)
+            },
+        )
+}
+
+// Begin ballot process for each party.
+fn launch_parties(
+    parties: Vec<Party<MockValue, MockValueSelector>>,
+) -> Vec<JoinHandle<Result<Option<MockValue>, LaunchBallotError>>> {
+    parties
+        .into_iter()
+        .map(|mut party| tokio::spawn(async move { party.launch_ballot().await }))
+        .collect()
+}
+
+// Collect messages from receivers.
+fn collect_messages(receivers: &mut [UnboundedReceiver<MessagePacket>]) -> Vec<MessagePacket> {
+    receivers
+        .iter_mut()
+        .filter_map(|receiver| receiver.try_recv().ok())
+        .collect()
+}
+
+// Broadcast collected messages to other parties, skipping the sender.
+fn broadcast_messages(messages: Vec<MessagePacket>, senders: &[UnboundedSender<MessagePacket>]) {
+    messages.iter().for_each(|msg| {
+        senders
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| msg.routing.sender != *i as u64) // Skip the current party (sender).
+            .for_each(|(_, sender_into)| {
+                sender_into.send(msg.clone()).unwrap();
+            });
+    });
+}
+
+// Propagate messages peer-to-peer between parties using their channels.
+fn propagate_messages_p2p(
+    mut receivers: Vec<UnboundedReceiver<MessagePacket>>,
+    senders: Vec<UnboundedSender<MessagePacket>>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            let messages = collect_messages(receivers.as_mut_slice());
+            broadcast_messages(messages, &senders);
+
+            // Delay to simulate network latency.
+            time::sleep(time::Duration::from_millis(100)).await;
+        }
+    })
+}
+
+// Await completion of each party's process and aggregate ok results.
+async fn extract_values_from_ballot_tasks(
+    tasks: Vec<JoinHandle<Result<Option<MockValue>, LaunchBallotError>>>,
+) -> Vec<MockValue> {
+    let mut values = Vec::new();
+    for (i, task) in tasks.into_iter().enumerate() {
+        let result = task.await.unwrap();
+
+        match result {
+            Ok(Some(value)) => {
+                values.push(value);
+            }
+            Ok(None) => {
+                // This shall never happen for finished party.
+                eprintln!("Party {}: No value was selected", i);
+            }
+            Err(err) => {
+                eprintln!("Party {} encountered an error: {:?}", i, err);
+            }
+        }
+    }
+    values
+}
+
+// Use returned values from each party to analyze how ballot passed.
+fn analyze_ballot_result(values: Vec<MockValue>) {
+    match values.as_slice() {
+        [] => {
+            eprintln!("No consensus could be reached, as no values were selected by any party")
+        }
+        [first_value, ..] => {
+            match values.iter().all(|v| v == first_value) {
+                true => println!(
+                    "All parties reached the same consensus value: {:?}",
+                    first_value
+                ),
+                false => eprintln!("Not all parties agreed on the same value"),
+            }
+            println!("Consensus agreed on value {first_value:?}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_ballot_happy_case() {
+    let (parties, receivers, senders) = create_parties(BPConConfig::default());
+
+    let ballot_tasks = launch_parties(parties);
+
+    let p2p_task = propagate_messages_p2p(receivers, senders);
+
+    let values = extract_values_from_ballot_tasks(ballot_tasks).await;
+
+    p2p_task.abort();
+
+    analyze_ballot_result(values);
+}
+
+#[tokio::test]
+async fn test_ballot_faulty_party() {
+    let (mut parties, mut receivers, mut senders) = create_parties(BPConConfig::default());
+
+    let leader = parties[0].ballot();
+
+    assert_ne!(3, leader, "Should not fail the leader for the test to pass");
+
+    // Simulate failure of `f` faulty participants:
+    let parties = parties.drain(..3).collect();
+    let receivers = receivers.drain(..3).collect();
+    let senders = senders.drain(..3).collect();
+
+    let ballot_tasks = launch_parties(parties);
+
+    let p2p_task = propagate_messages_p2p(receivers, senders);
+
+    let values = extract_values_from_ballot_tasks(ballot_tasks).await;
+
+    p2p_task.abort();
+
+    analyze_ballot_result(values);
+}
+
+#[tokio::test]
+async fn test_ballot_malicious_party() {
+    let (parties, mut receivers, senders) = create_parties(BPConConfig::default());
+
+    let leader = parties[0].ballot();
+    const MALICIOUS_PARTY_ID: u64 = 1;
+
+    assert_ne!(
+        MALICIOUS_PARTY_ID, leader,
+        "Should not make malicious the leader for the test to pass"
+    );
+
+    // We will be simulating malicious behaviour
+    // sending 1b message (meaning, 5/6 times at incorrect stage) with the wrong data.
+    let content = &Message1bContent {
+        ballot: parties[0].ballot() + 1, // divergent ballot number
+        last_ballot_voted: Some(parties[0].ballot() + 1), // early ballot number
+        // shouldn't put malformed serialized value, because we won't be able to pack it
+        last_value_voted: None,
+    };
+    let malicious_msg = content.pack(MALICIOUS_PARTY_ID).unwrap();
+
+    let ballot_tasks = launch_parties(parties);
+
+    let p2p_task = tokio::spawn(async move {
+        let mut last_malicious_message_time = time::Instant::now();
+        let malicious_message_interval = time::Duration::from_millis(3000);
+        loop {
+            // Collect all messages first.
+            let mut messages: Vec<_> = receivers
+                .iter_mut()
+                .enumerate()
+                .filter_map(|(i, receiver)| {
+                    // Skip receiving messages from the malicious party
+                    // to substitute it with invalid one to be propagated.
+                    (i != MALICIOUS_PARTY_ID as usize)
+                        .then(|| receiver.try_recv().ok())
+                        .flatten()
+                })
+                .collect();
+
+            // Push the malicious message at intervals
+            // to mitigate bloating inner receiving channel.
+            if last_malicious_message_time.elapsed() >= malicious_message_interval {
+                messages.push(malicious_msg.clone());
+                last_malicious_message_time = time::Instant::now();
+            }
+
+            broadcast_messages(messages, &senders);
+
+            // Delay to simulate network latency.
+            time::sleep(time::Duration::from_millis(100)).await;
+        }
+    });
+
+    let values = extract_values_from_ballot_tasks(ballot_tasks).await;
+
+    p2p_task.abort();
+
+    analyze_ballot_result(values);
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -11,6 +11,19 @@ use tokio::time::{sleep, Duration, Instant};
 
 use futures::future::join_all;
 
+/// Returns config with fast timeouts.
+fn get_fast_config() -> BPConConfig {
+    BPConConfig{
+        launch1a_timeout: Duration::from_millis(0),
+        launch1b_timeout: Duration::from_millis(50),
+        launch2a_timeout: Duration::from_millis(100),
+        launch2av_timeout: Duration::from_millis(150),
+        launch2b_timeout: Duration::from_millis(200),
+        finalize_timeout: Duration::from_millis(250),
+        ..Default::default()
+    }
+}
+
 /// Here each party/receiver/sender shall correspond at equal indexes.
 type PartiesWithChannels = (
     Vec<MockParty>,
@@ -81,8 +94,8 @@ fn propagate_p2p(
             let messages = collect_messages(receivers.as_mut_slice());
             broadcast_messages(messages, &senders);
 
-            // Delay to simulate network latency and reduce processor load.
-            sleep(Duration::from_millis(100)).await;
+            // Reduce processor load.
+            sleep(Duration::from_millis(1)).await;
         }
     })
 }
@@ -152,7 +165,7 @@ async fn run_ballot_faulty_party(
 
 #[tokio::test]
 async fn test_ballot_happy_case() {
-    let (parties, receivers, senders) = create_parties(BPConConfig::default());
+    let (parties, receivers, senders) = create_parties(get_fast_config());
     let ballot_tasks = launch_parties(parties);
     let p2p_task = propagate_p2p(receivers, senders);
     let results = await_results(ballot_tasks).await;
@@ -163,7 +176,7 @@ async fn test_ballot_happy_case() {
 
 #[tokio::test]
 async fn test_ballot_faulty_party_common() {
-    let parties = create_parties(BPConConfig::default());
+    let parties = create_parties(get_fast_config());
     let elector = DefaultLeaderElector::new();
     let leader = elector.elect_leader(&parties.0[0]).unwrap();
     let faulty_ids: Vec<usize> = vec![3];
@@ -180,7 +193,7 @@ async fn test_ballot_faulty_party_common() {
 
 #[tokio::test]
 async fn test_ballot_faulty_party_leader() {
-    let parties = create_parties(BPConConfig::default());
+    let parties = create_parties(get_fast_config());
     let elector = DefaultLeaderElector::new();
     let leader = elector.elect_leader(&parties.0[0]).unwrap();
     let faulty_ids = vec![leader as usize];
@@ -223,7 +236,7 @@ async fn test_ballot_malicious_party() {
         // actors would be able to DDoS ballot, bloating all the channel with malicious ones.
         // For this test to pass, we will send malicious messages once in a while.
         let mut last_malicious_message_time = Instant::now();
-        let malicious_message_interval = Duration::from_secs(3);
+        let malicious_message_interval = Duration::from_millis(100);
         loop {
             // Collect all messages first.
             let mut messages: Vec<_> = receivers


### PR DESCRIPTION
# What?

All tests refactored - added clarity on what is tested, comments, enhanced homogeneity of codebase, made it more rust-idiomatic.
Introducing shared test mocks package available with feature `test-mocks`.
Moved end-to-end tests to `/tests` as they describe integration.
Added more integration coverage.

## Changes apart from tests

### Fixed Bugs:
1. Threshold check is now `≥` instead of `>` as it should be in BFT requirement.
2. Threshold now accounts for party's own weight.

### New Features:
1. Rate-limiting for incoming messages.
2. Threshold computation function to `BPConConfig`.  
3. Migrate CI test running to [nextest-rs](https://nexte.st/).

## Analysis on end-to-end coverage

### Categories of parties

1. `Good` - party sends messages to other participants based on following events, and correctly receives and processes messages from other parties.

2. `Faulty`  - party has troubles receiving/sending messages. These are simply mitigated by the weighed threshold and redundancy of consensus participants.

3. `Malicious` - party launches DDoS attack using unbounded sending of messages - to deal with this, we introduce rate-limiting mechanism in accepting messages inside the `Party`, however it is also required by integrating 'external' system, which handles `P2P`, to attest to this, because otherwise receiving channel may get flooded by malicious messages and block messages from other parties. Another way to cause trouble is by sending invalid messages. For this, each party has a set of checks for certain fields like current ballot number, status, etc. Additionally, if the state transition caused by incoming message errored, it does not impact the party in either way. 

### Note on the leader

If the `leader` of the ballot is faulty or malicious, the ballot deterministically fails and needs to be relaunched.

### Note on the communication discrepancies

Each party has a certain period in which it may accept particular messages for a certain stage (example: having passed 1a stage, it is open for accepting only 1b messages for 2 seconds). These periods are configurable using `BPConConfig`.

In addition, it is possible to schedule parties to launch at a specific absolute time.

